### PR TITLE
ci(release): add job permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,11 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -39,5 +44,5 @@ jobs:
       - name: Release
         run: yarn semantic-release
         env:
-          GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -53,7 +53,7 @@
       "@semantic-release/github",
       {
         "assets": [
-          { "path": "dist/**/*.js", "label": "NPM Package" }
+          { "path": "dist/**", "label": "NPM Package" }
         ]
       }
     ],

--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
     "semantic-release": "^21.0.5",
     "ts-jest": "^29.1.0",
     "typescript": "^5.1.5"
-  }
+  },
+  "packageManager": "yarn@3.6.0"
 }


### PR DESCRIPTION
Add extra permissions to workflow in hopes that github step no longer fails
